### PR TITLE
Use "css-property-parser" for expanding properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,16 +1,18 @@
 'use strict'
 
 var postcss = require('postcss')
-var isShorthand = require('is-css-shorthand')
-var shorthandExpand = require('css-shorthand-expand')
+const {
+  isShorthandProperty,
+  expandShorthandProperty
+} = require('css-property-parser');
 
 module.exports = postcss.plugin('postcss-shorthand-expand', function () {
   return function removePrefixes (root, result) {
     root.walkRules(function (rule) {
       rule.walkDecls( function (declaration) {
-        if (isShorthand(declaration.prop) && isSupportedShorthand(declaration.prop)) {
+        if (isShorthandProperty(declaration.prop)) {
           try {
-            var expandedDecls = shorthandExpand(declaration.prop, declaration.value)
+            var expandedDecls = expandShorthandProperty(declaration.prop, declaration.value)
 
             Object.keys(expandedDecls).forEach(function (prop) {
               rule.insertBefore(declaration, { prop: prop, value: expandedDecls[prop] })
@@ -25,13 +27,6 @@ module.exports = postcss.plugin('postcss-shorthand-expand', function () {
     })
   }
 })
-
-// css-shorthand-expand doesn't yet support all shorthands
-function isSupportedShorthand (shorthand) {
-  return ['background', 'font', 'padding', 'margin', 'border', 'border-width',
-          'border-style', 'border-color', 'border-top', 'border-right', 'border-left',
-          'border-bottom'].indexOf(shorthand) >= 0
-}
 
 function getExpansionFailureDescription (decl, result) {
   result.warn(

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "css-shorthand-expand": "^1.0.1",
-    "is-css-shorthand": "^1.0.0",
+    "css-property-parser": "^1.0.6",
     "postcss": "^5.0.8"
   },
   "devDependencies": {

--- a/test/fixtures/output.css
+++ b/test/fixtures/output.css
@@ -6,10 +6,10 @@
 
 .some-font {
   font-family: sans-serif;
-  font-size: 16px;
   line-height: 1.2;
+  font-size: 16px;
 }
 
 .unhandled-shorthand {
-  list-style: none;
+  list-style-image: none;
 }


### PR DESCRIPTION
Use "css-property-parser" mode which is more advanced and is based on MDN data. It is up to date and also used by http://css-blocks.com